### PR TITLE
fix: 存在しないスキル参照を削除

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-efficiency",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "サブエージェント活用によるコンテキスト効率化プラグイン",
   "author": {
     "name": "satorun"

--- a/skills/orchestrating-tasks/SKILL.md
+++ b/skills/orchestrating-tasks/SKILL.md
@@ -93,8 +93,6 @@ allowed-tools:
 ## 関連スキル
 
 - **building-task-prompts**: サブエージェント用プロンプト生成（本スキルから利用）
-- **task-driven-development**: チェックポイント付きの仕様駆動実装
-- **spec-workflow-orchestrator**: 完全な仕様駆動ワークフロー管理
 
 ## 参照ドキュメント
 


### PR DESCRIPTION
## Summary
- orchestrating-tasksから存在しないスキル参照を削除
  - `task-driven-development`
  - `spec-workflow-orchestrator`
- バージョンを `0.0.1` → `0.0.2` に更新

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>